### PR TITLE
docs: adjust import syntax of aws_cognito_resource_server

### DIFF
--- a/website/docs/r/cognito_resource_server.markdown
+++ b/website/docs/r/cognito_resource_server.markdown
@@ -72,5 +72,5 @@ In addition to all arguments above, the following attributes are exported:
 `aws_cognito_resource_server` can be imported using their User Pool ID and Identifier, e.g.,
 
 ```
-$ terraform import aws_cognito_resource_server.example us-west-2_abc123:https://example.com
+$ terraform import aws_cognito_resource_server.example "us-west-2_abc123|https://example.com"
 ```


### PR DESCRIPTION
### Description

The [code](https://github.com/hashicorp/terraform-provider-aws/blob/ae683662502d49e73caf3a8d01fb4689ab400592/internal/service/cognitoidp/resource_server.go#L222) expects to receive a "PoolId|ResourceServerIdentifier" string, not a colon separated string.